### PR TITLE
CODEOWNERS: owning team Devices - Integration (273)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# CODEOWNERS — default owner is the repository's owning team.
+# Managed by EngOps (scripts/sync-codeowners.js). Team: Devices - Integration (273).
+* @EENCloud/devices-integration-273


### PR DESCRIPTION
Ensures **EEConnect** has a CODEOWNERS file naming its owning team **Devices - Integration (273)** (`@EENCloud/devices-integration-273`).

**Changes:** create .github/CODEOWNERS (@EENCloud/devices-integration-273)

_Opened by `scripts/sync-codeowners.js` (EngOps). The owning team comes from `truths/repositories.json` → `truths/teams.json`._
